### PR TITLE
Hardcode packages variable in setup.py to prevent installation of files in 'tests' directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ exec(compile(open('spotify_videos/version.py').read(),
 setup(
     name='spotify-videos',
     version=__version__,
-    packages=['spotify-videos'],
+    packages=['spotify_videos'],
     description='Simple tool to show Youtube music videos and lyrics'
                 ' for the playing Spotify songs',
     url='https://github.com/marioortizmanero/spotify-music-videos',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 import platform
 
 
@@ -22,7 +22,7 @@ exec(compile(open('spotify_videos/version.py').read(),
 setup(
     name='spotify-videos',
     version=__version__,
-    packages=find_packages(),
+    packages=['spotify-videos']
     description='Simple tool to show Youtube music videos and lyrics'
                 ' for the playing Spotify songs',
     url='https://github.com/marioortizmanero/spotify-music-videos',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ exec(compile(open('spotify_videos/version.py').read(),
 setup(
     name='spotify-videos',
     version=__version__,
-    packages=['spotify-videos']
+    packages=['spotify-videos'],
     description='Simple tool to show Youtube music videos and lyrics'
                 ' for the playing Spotify songs',
     url='https://github.com/marioortizmanero/spotify-music-videos',


### PR DESCRIPTION
Hello,

I've ran into a small problem with the setup.py file.  Portage (gentoo's package manager) kept complaining about my ebuild:

```
>>> Failed to emerge dev-python/spotify-music-videos-1.8, Log file:

>>>  '/var/tmp/portage/dev-python/spotify-music-videos-1.8/temp/build.log'

* Messages for package dev-python/spotify-music-videos-1.8:

* ERROR: dev-python/spotify-music-videos-1.8::localrepo failed (install phase):
*   Package installs 'tests' package which is forbidden and likely a bug in the build system.
* 
* Call stack:
*     ebuild.sh, line  125:  Called src_install
*   environment, line 3423:  Called distutils-r1_src_install
*   environment, line 1119:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
*   environment, line  466:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
*   environment, line 2970:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
*   environment, line 2284:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
*   environment, line 2282:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
*   environment, line  803:  Called distutils-r1_run_phase 'distutils-r1_python_install'
*   environment, line 1087:  Called distutils-r1_python_install
*   environment, line 1005:  Called die
* The specific snippet of code:
*               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
```

I was a bit confused about this, as I also wrote ebuilds for some dependencies (lyricwikia, python-vlc) which also have a 'tests' directory, yet portage was absolutely fine with these ebuilds.

In my initial ebuild I fixed this by just patching out the whole 'tests' directory prior to installing. However, this solution is imperfect so I kept looking for what was differentiating this repository from the lyricwikia one.

It took some time but I finally found the problem, in setup.py. The line `packages=find_packages(),` causes setuptools to find all directories, including 'tests', (which shouldn't be installed). Hardcoding it to `['spotify-videos']` similarly to the setup.py's I found in other repositories fixes the problem.

[EDIT]: See also: https://github.com/gentoo/gentoo/pull/13870