### PR TITLE
Fix setup.py, added find_packages again but this time using the exclude= option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * You can download the latest stable [release](https://github.com/marioortizmanero/vidify/releases). There should be binaries avaliable for Mac OS, Linux and Windows. These already include mpv support and most of the supported APIs.
 * Linux:
     * Arch Linux: you can install it from the AUR: [`vidify`](https://aur.archlinux.org/packages/vidify/). Read the optional dependencies to use more APIs and players. Maintained by me ([marioortizmanero](https://github.com/marioortizmanero)).
-    * Gentoo: there's an e-build maintained by [AndrewAmmerlaan](https://github.com/AndrewAmmerlaan) at [dev-python/vidify](https://packages.gentoo.org/packages/dev-python/vidify).
+    * Gentoo: there's an e-build maintained by [AndrewAmmerlaan](https://github.com/AndrewAmmerlaan) at [media-video/vidify](https://packages.gentoo.org/packages/media-video/vidify).
     * Feel free to upload it to your distro's repositories! Let me know in an issue so that I can add it to this list.
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 # Get version inside vidify/version.py without importing the package
@@ -8,12 +8,16 @@ exec(compile(open('vidify/version.py').read(),
 setup(
     name='vidify',
     version=__version__,
-    packages=['vidify'],
+    packages=find_packages(exclude=('tests*', 'dev*')),
     description='Watch music videos for the songs playing on your device',
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/marioortizmanero/vidify',
     license='LGPL',
+
+    package_data={'vidify': ['gui/res/*',
+                             'gui/res/**/*',
+                             'gui/res/**/**/*']},
 
     author='Mario O.M.',
     author_email='marioortizmanero@gmail.com',


### PR DESCRIPTION
Hi, 

I have been checking out the next branch to prepare an ebuild for the 2.0 release, and to check if all the dependencies are available in the Gentoo repo's. In doing so I ran into a small problem. Apparently, the `packages=` variable in `setup.py` does not include subdirectories. This means that the current `setup.py` file does not install vidify.gui, vidify.api and vidify.player. I have made this PR to fix that, I have reintroduced `find_packages` but I have added the `exclude=` option to prevent installation of the `tests` and `dev` directories, to prevent regression of: https://github.com/marioortizmanero/spotify-music-videos/pull/32.

This time I tested it before making the PR :smile: 

Also, might I suggest to use https://github.com/spyder-ide/qtpy instead of importing PySide2 directly. QtPy is a abstraction layer for PyQt(5) and PySide(2), using this instead of explicitly choosing for PySide2 would increase compatibility with distros that only have one of the two. And it would also prevent users having to install both PyQt5 and PySide2. It is my understanding that PySide2 and PyQt5 are almost identical anyway, and it should be possible to just replace all `import PySide.foobar` with `import qtpy.foobar` without breaking anything. I can test this later, and if you want I can make a PR for this. ([edit] Yes, replacing PySide2 with QtPy works just fine: https://github.com/marioortizmanero/spotify-music-videos/pull/35)

### [EDIT] 
Happy New Year

### [EDIT2] 
I also added a `MANIFEST.in` file, to make sure that all the files in `vidify/gui/res` are installed as well, otherwise the icons etc will be missing.

### [EDIT3] 
I also get this warning when starting vidify:
```
qt.svg: Cannot open file '/home/andrew/vidify/gui/res/icon.svg', because: No such file or directory
qt.svg: Cannot open file '/home/andrew/vidify/gui/res/icon.svg', because: No such file or directory
```
It seems it is looking for icon files in the current working directory instead of in the directory where it is installed (`/usr/lib/python3.7/site-packages/vidify`). I haven't quite figured out how to fix this though.

Maybe something like this would work:
```
os.chdir(os.path.dirname(sys.argv[0]))
```
But I'm not sure if that is the 'correct' solution, there probably is some convention on doing this.

### [EDIT4] 
Is it possible to get the font-colour to correspond to the current qt theme's font colour?
![Screenshot_20191231_204335](https://user-images.githubusercontent.com/8460628/71632347-58d8f800-2c0e-11ea-8dca-c2c5c106def0.png)
(The icons are only shown when running from the `/usr/lib/python3.7/site-packages/vidify` directory)

[edit] Yes, we can get the font to match the theme, with this patch:
```
diff --git a/vidify/gui/components.py b/vidify/gui/components.py
index 7b34d4a..0e11f5c 100644
--- a/vidify/gui/components.py
+++ b/vidify/gui/components.py
@@ -52,7 +52,6 @@ class APICard(QGroupBox):
         text = QLabel(description)
         text.setWordWrap(True)
         text.setFont(Fonts.smalltext)
-        text.setStyleSheet(f"color: {Colors.fg};")
         text.setAlignment(Qt.AlignHCenter)
         self.layout.addWidget(text)
 ```
