### PR TITLE
Fix logic in determining whether to add PySide2 or PyQt5 to deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@ from setuptools import setup, find_packages
 from pkg_resources import DistributionNotFound, get_distribution
 
 
-def get_dist(pkgname):
+def is_installed(pkgname: str) -> bool:
     try:
-        return get_distribution(pkgname)
+        get_distribution(pkgname)
+        return True
     except DistributionNotFound:
-        return None
+        return False
 
 
 # Get version inside vidify/version.py without importing the package
@@ -25,8 +26,12 @@ install_deps = [
     ' or platform_system=="Darwin"'
 ]
 
-if ((get_dist('PyQt5') is None or get_dist('PyQtWebEngine') is None)
-        and get_dist('PySide2') is None):
+# If PySide2 is installed and PyQt5 is not, append PySide2 to dependencies
+if is_installed('PySide2') and not is_installed('PyQt5'):
+    install_deps.append('PySide2')
+# If PySide2 is not installed, or if both PyQt5 and PySide2 are installed
+# Use QtPy's default: PyQt5
+else:
     install_deps.append('PyQt5')
     install_deps.append('PyQtWebEngine')
 
@@ -41,8 +46,8 @@ setup(
     license='LGPL',
 
     package_data={'vidify': ['gui/res/*',
-                             'gui/res/**/*',
-                             'gui/res/**/**/*']},
+                             'gui/res/*/*',
+                             'gui/res/*/*/*']},
 
     author='Mario O.M.',
     author_email='marioortizmanero@gmail.com',


### PR DESCRIPTION
I just realized that my logic in determining whether or not to append PyQt5 to dependencies does not correctly handle the case where PyQt5 AND PySide2 are installed but not PyQtWebengine: (False or True) and False == False where it should be true.

```
if ((get_dist('PyQt5') is None or get_dist('PyQtWebEngine') is None)
        and get_dist('PySide2') is None):
    install_deps.append('PyQt5')
    install_deps.append('PyQtWebEngine')
```

Instead I propose this logic:
```
if get_dist('PySide2') is not None:
    install_deps.append('PySide2')
else:
    install_deps.append('PyQt5')
    install_deps.append('PyQtWebEngine')
```
Now, if PySide2 is not None (=installed) it is appended to the dependencies. If not, then it reverts to append PyQt5 and PyQtWebengine. I think this (simpler) logic should cover all cases. What do you think, is this better?

I also changed the `**` to `*` because it does the same. In theory the double `**` should match  recursively: https://docs.python.org/3/library/glob.html but apparently it doesn't work like that in `package_data` because otherwise `'gui/res/**` would already be enough to also install the subdirectories (which it is not, without the other two lines it doesn't install the subdirectories).